### PR TITLE
Feature/composer auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,15 @@ The tool has several options which can be configured via GitLab CI variables, ei
 
 |CI environment variable|Default|Description|
 --- | :---: | ---
-|**`COMPOSER_MR_TOKEN`**       |      |**User token for merge requests (required)**        |
-|`COMPOSER_MR_COMPOSER_VERSION`|`2`   |Composer version (1 or 2)                           |
-|`COMPOSER_MR_BRANCH_PREFIX`   |      |MR branch prefix, eg "feature/"                     |
-|`COMPOSER_MR_LABELS`          |      |MR labels (comma-separated)                         |
-|`COMPOSER_MR_ASSIGNEES`       |      |MR assignees (comma-separated usernames)            |
-|`COMPOSER_MR_REVIEWERS`       |      |MR reviewers (comma-separated usernames)            |
-|`COMPOSER_MR_REPLACE_OPEN`    |`true`|Replace outdated open composer-update merge requests|
+|**`COMPOSER_MR_TOKEN`**       |      |**User token for merge requests (required)**         |
+|`COMPOSER_MR_COMPOSER_VERSION`|`2`   |Composer version (1 or 2)                            |
+|`COMPOSER_MR_BRANCH_PREFIX`   |      |MR branch prefix, eg "feature/"                      |
+|`COMPOSER_MR_LABELS`          |      |MR labels (comma-separated)                          |
+|`COMPOSER_MR_ASSIGNEES`       |      |MR assignees (comma-separated usernames)             |
+|`COMPOSER_MR_REVIEWERS`       |      |MR reviewers (comma-separated usernames)             |
+|`COMPOSER_MR_REPLACE_OPEN`    |`true`|Replace outdated open composer-update merge requests |
+|`COMPOSER_MR_GITLAB_DOMAIN`   |      |Domain of your GitLab instance                       |
+|`COMPOSER_MR_AUTH_TOKEN`      |      |API key or `CI_JOB_TOKEN` to access composer registry|
 
 
 ## Environment variable notes
@@ -112,6 +114,29 @@ GitLab Composer Updater MR will always add a checksum of the `composer.lock` to 
 If no matching checksum in a merge request is found, then any previous outdated **open** merge request is closed and their branches removed. If you do not want this behavior then set this environment variable to `false`.
 
 In both instances, merge requests must match the same labels (if set), created by the same user (that owns the `COMPOSER_MR_TOKEN`), and have a title starting with `Composer update: `.
+
+
+### `COMPOSER_MR_GITLAB_DOMAIN` and `COMPOSER_MR_AUTH_TOKEN`
+
+If you host private [composer packages](https://docs.gitlab.com/ee/user/packages/composer_repository/) in your GitLab instance, use these two variables to configure composer with credentials to access them.
+
+Example:
+
+```yaml
+stages:
+  - composer-update-mr
+
+composer-update-mr:
+  stage: composer-update-mr
+  image: axllent/gitlabci-composer-update-mr:<php-version>
+  only:
+    - schedules
+  variables:
+    COMPOSER_MR_GITLAB_DOMAIN: $CI_SERVER_HOST
+    COMPOSER_MR_AUTH_TOKEN: $CI_JOB_TOKEN # or $COMPOSER_MR_TOKEN
+  script:
+    - gitlabci-composer-update-mr <commit-user> <commit-email> <source-branch>
+```
 
 
 ## Building your own docker images

--- a/app/composer.go
+++ b/app/composer.go
@@ -15,6 +15,11 @@ func ComposerUpdate() (string, error) {
 	return run(Config.ComposerPath, "update", "--no-progress")
 }
 
+// ComposerAuth will set auth credentials
+func ComposerAuth(domain, token) (string, error) {
+	return run(Config.ComposerPath, "config", "http-basic." + domain + " ___token___ "+ token)
+}
+
 // ParseComposerLock parses a composer lock file
 func ParseComposerLock() (ComposerLock, error) {
 	var v = ComposerLock{}

--- a/app/config.go
+++ b/app/config.go
@@ -75,6 +75,10 @@ func BuildConfig() {
 		}
 	}
 
+	if len(envString("COMPOSER_MR_GITLAB_DOMAIN", "")) > 0 && len(envString("COMPOSER_MR_AUTH_TOKEN", "")) > 0 {
+		app.ComposerAuth(envString("COMPOSER_MR_GITLAB_DOMAIN", ""), envString("COMPOSER_MR_AUTH_TOKEN", ""))
+	}
+
 	if len(errors) > 0 {
 		fmt.Println("\n==========\nError:")
 		for _, err := range errors {

--- a/app/git.go
+++ b/app/git.go
@@ -37,7 +37,7 @@ func CreateMergeBranch() error {
 		fmt.Println(out)
 		return err
 	}
-	if out, err := runQuiet(Config.GitPath, "add", "."); err != nil {
+	if out, err := runQuiet(Config.GitPath, "add", "composer.json composer.lock"); err != nil {
 		fmt.Println(out)
 		return err
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,9 +25,6 @@ Documentation:
 		app.Config.GitEmail = args[1]
 		app.Config.GitBranch = args[2]
 
-		// Set composer auth for privately-hosted packages.
-		os.Setenv("COMPOSER_AUTH", os.Getenv("COMPOSER_MR_TOKEN"))
-
 		app.BuildConfig()
 
 		if err := app.SwitchBranch(app.Config.GitBranch); err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,9 @@ Documentation:
 		app.Config.GitEmail = args[1]
 		app.Config.GitBranch = args[2]
 
+		// Set composer auth for privately-hosted packages.
+		os.Setenv("COMPOSER_AUTH", os.Getenv("COMPOSER_MR_TOKEN"))
+
 		app.BuildConfig()
 
 		if err := app.SwitchBranch(app.Config.GitBranch); err != nil {


### PR DESCRIPTION
@axllent I’ve run into another issue; some of our apps use private composer packages hosted by our GitLab instance ([docs](https://docs.gitlab.com/ee/user/packages/composer_repository/)).

Running this command on those apps results in this error:

```
  [Composer\Downloader\TransportException]                                                                                        
  The "https://git.my-gitlab-server/api/v4/group/242/-/packages/composer/packages.json" file could not be downloaded (HTTP/2 404 ):  
  {"message":"404 Group Not Found"}                                                                                               
```

(Arguably GitLab should respond with `401` rather than `404` but ¯\\\_(ツ)\_/¯)

In other pipelines (phpunit tests, for example), I handle this by running this script step:

```yml
phpunit:
  script:
    - composer config http-basic.git.my-gitlab-server ___token___ "$PERSONAL_ACCESS_TOKEN"
    - composer install
    - phpunit # etc.
```

I tried this first, but the docker image doesn’t have `composer` installed so it failed.

For now I’ve built a “prep” job that creates and caches an `auth.json`, and this works fine:

```yml
cache:
  paths:
    - auth.json

composer-mr:prep:
  stage: composer_mr_prep
  script:
    - composer config http-basic.git.my-gitlab-server ___token___ "$COMPOSER_MR_TOKEN"

composer-mr:
  stage: composer_mr
  script:
    - gitlabci-composer-update-mr username email@email branch
```

---

This PR adds two new variables used by `composer config` to set auth credentials.

Again, I’m not a Go developer, so I’m not quite sure I have the syntax correct, but does this idea make sense to you and seem like the best way to accomplish this?

Thanks again!