### PR TITLE
add PHP pcntl extension

### DIFF
--- a/docker/Dockerfile-5.6
+++ b/docker/Dockerfile-5.6
@@ -14,7 +14,7 @@ RUN apk add --no-cache git bash icu-libs \
 && wget https://getcomposer.org/download/latest-1.x/composer.phar -O /usr/local/bin/composer-1 && chmod +x /usr/local/bin/composer-1 \
 && wget https://getcomposer.org/download/latest-stable/composer.phar -O /usr/local/bin/composer-2 && chmod +x /usr/local/bin/composer-2 \
 && apk add --no-cache --virtual build-dependencies icu-dev \
-&& docker-php-ext-install intl && apk del build-dependencies
+&& docker-php-ext-install intl pcntl && apk del build-dependencies
 
 COPY --from=builder /app/gitlabci-composer-update-mr /usr/local/bin/gitlabci-composer-update-mr
 

--- a/docker/Dockerfile-7.0
+++ b/docker/Dockerfile-7.0
@@ -14,7 +14,7 @@ RUN apk add --no-cache git bash icu-libs \
 && wget https://getcomposer.org/download/latest-1.x/composer.phar -O /usr/local/bin/composer-1 && chmod +x /usr/local/bin/composer-1 \
 && wget https://getcomposer.org/download/latest-stable/composer.phar -O /usr/local/bin/composer-2 && chmod +x /usr/local/bin/composer-2 \
 && apk add --no-cache --virtual build-dependencies icu-dev \
-&& docker-php-ext-install intl && apk del build-dependencies
+&& docker-php-ext-install intl pcntl && apk del build-dependencies
 
 COPY --from=builder /app/gitlabci-composer-update-mr /usr/local/bin/gitlabci-composer-update-mr
 

--- a/docker/Dockerfile-7.1
+++ b/docker/Dockerfile-7.1
@@ -14,7 +14,7 @@ RUN apk add --no-cache git bash icu-libs \
 && wget https://getcomposer.org/download/latest-1.x/composer.phar -O /usr/local/bin/composer-1 && chmod +x /usr/local/bin/composer-1 \
 && wget https://getcomposer.org/download/latest-stable/composer.phar -O /usr/local/bin/composer-2 && chmod +x /usr/local/bin/composer-2 \
 && apk add --no-cache --virtual build-dependencies icu-dev \
-&& docker-php-ext-install intl && apk del build-dependencies
+&& docker-php-ext-install intl pcntl && apk del build-dependencies
 
 COPY --from=builder /app/gitlabci-composer-update-mr /usr/local/bin/gitlabci-composer-update-mr
 

--- a/docker/Dockerfile-7.2
+++ b/docker/Dockerfile-7.2
@@ -14,7 +14,7 @@ RUN apk add --no-cache git bash icu-libs \
 && wget https://getcomposer.org/download/latest-1.x/composer.phar -O /usr/local/bin/composer-1 && chmod +x /usr/local/bin/composer-1 \
 && wget https://getcomposer.org/download/latest-stable/composer.phar -O /usr/local/bin/composer-2 && chmod +x /usr/local/bin/composer-2 \
 && apk add --no-cache --virtual build-dependencies icu-dev \
-&& docker-php-ext-install intl && apk del build-dependencies
+&& docker-php-ext-install intl pcntl && apk del build-dependencies
 
 COPY --from=builder /app/gitlabci-composer-update-mr /usr/local/bin/gitlabci-composer-update-mr
 

--- a/docker/Dockerfile-7.3
+++ b/docker/Dockerfile-7.3
@@ -14,7 +14,7 @@ RUN apk add --no-cache git bash icu-libs \
 && wget https://getcomposer.org/download/latest-1.x/composer.phar -O /usr/local/bin/composer-1 && chmod +x /usr/local/bin/composer-1 \
 && wget https://getcomposer.org/download/latest-stable/composer.phar -O /usr/local/bin/composer-2 && chmod +x /usr/local/bin/composer-2 \
 && apk add --no-cache --virtual build-dependencies icu-dev \
-&& docker-php-ext-install intl && apk del build-dependencies
+&& docker-php-ext-install intl pcntl && apk del build-dependencies
 
 COPY --from=builder /app/gitlabci-composer-update-mr /usr/local/bin/gitlabci-composer-update-mr
 

--- a/docker/Dockerfile-7.4
+++ b/docker/Dockerfile-7.4
@@ -14,7 +14,7 @@ RUN apk add --no-cache git bash icu-libs \
 && wget https://getcomposer.org/download/latest-1.x/composer.phar -O /usr/local/bin/composer-1 && chmod +x /usr/local/bin/composer-1 \
 && wget https://getcomposer.org/download/latest-stable/composer.phar -O /usr/local/bin/composer-2 && chmod +x /usr/local/bin/composer-2 \
 && apk add --no-cache --virtual build-dependencies icu-dev \
-&& docker-php-ext-install intl && apk del build-dependencies
+&& docker-php-ext-install intl pcntl && apk del build-dependencies
 
 COPY --from=builder /app/gitlabci-composer-update-mr /usr/local/bin/gitlabci-composer-update-mr
 

--- a/docker/Dockerfile-8.0
+++ b/docker/Dockerfile-8.0
@@ -14,7 +14,7 @@ RUN apk add --no-cache git bash icu-libs \
 && wget https://getcomposer.org/download/latest-1.x/composer.phar -O /usr/local/bin/composer-1 && chmod +x /usr/local/bin/composer-1 \
 && wget https://getcomposer.org/download/latest-stable/composer.phar -O /usr/local/bin/composer-2 && chmod +x /usr/local/bin/composer-2 \
 && apk add --no-cache --virtual build-dependencies icu-dev \
-&& docker-php-ext-install intl && apk del build-dependencies
+&& docker-php-ext-install intl pcntl && apk del build-dependencies
 
 COPY --from=builder /app/gitlabci-composer-update-mr /usr/local/bin/gitlabci-composer-update-mr
 


### PR DESCRIPTION
This adds PHP’s pcntl extension to the Docker image as it may be required by some apps.

If you’d rather not include more dependencies, I can create my own fork instead.