### PR TITLE
add COMPOSER_MR_TITLE_PREFIX variable for user-configurable MR titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The tool has several options which can be configured via GitLab CI variables, ei
 | `COMPOSER_MR_REVIEWERS`        |                                | MR reviewers (comma-separated usernames)             |
 | `COMPOSER_MR_REPLACE_OPEN`     | `true`                         | Replace outdated open composer-update merge requests |
 | `COMPOSER_MR_COMMIT_TITLE`     | `Update composer dependencies` | Set the commit message title (first line)            |
+| `COMPOSER_MR_TITLE_PREFIX`     | `Composer update: `            | Set the first part of the merge request title        |
 
 
 

--- a/app/config.go
+++ b/app/config.go
@@ -79,7 +79,7 @@ func BuildConfig() {
 
 	Config.GitCommitTitle = envString("COMPOSER_MR_COMMIT_TITLE", Config.GitCommitTitle)
 
-	Config.MRTitlePrefix = envString("COMPOSER_MR_TITLE_PREFIX", "Composer update: ")
+	Config.MRTitlePrefix = envString("COMPOSER_MR_TITLE_PREFIX", Config.MRTitlePrefix)
 
 	if len(errors) == 0 {
 		// test if project's merge requests are accessible

--- a/app/config.go
+++ b/app/config.go
@@ -38,6 +38,9 @@ var (
 		// MRBranch is the branch name for the merge request
 		MRBranch string
 
+		// MRTitlePrefix is the first part of the merge request title
+		MRTitlePrefix string
+
 		// GitCommitTitle is the first line of the git commit message
 		GitCommitTitle string
 	}
@@ -75,6 +78,8 @@ func BuildConfig() {
 	Config.MRBranch = fmt.Sprintf("%scomposer-update-%s", envString("COMPOSER_MR_BRANCH_PREFIX", ""), t)
 
 	Config.GitCommitTitle = envString("COMPOSER_MR_COMMIT_TITLE", Config.GitCommitTitle)
+
+	Config.MRTitlePrefix = envString("COMPOSER_MR_TITLE_PREFIX", "Composer update: ")
 
 	if len(errors) == 0 {
 		// test if project's merge requests are accessible

--- a/app/gitlab.go
+++ b/app/gitlab.go
@@ -137,7 +137,7 @@ func RemoveOldMRs() error {
 	}
 
 	for _, mr := range mrs {
-		if strings.HasPrefix(mr.Title, "Composer update: ") {
+		if strings.HasPrefix(mr.Title, Config.MRTitlePrefix) {
 			if err := deleteOriginBranch(mr.SourceBranch); err != nil {
 				return err
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -77,7 +77,7 @@ Documentation:
 			pkgs = "packages"
 		}
 
-		mrTitle := fmt.Sprintf(app.Config.MRTitlePrefix + "%d %s", len(diff.Packages), pkgs)
+		mrTitle := fmt.Sprintf("%s %d %s", app.Config.MRTitlePrefix, len(diff.Packages), pkgs)
 
 		if err := app.CreateMergeRequest(mrTitle, diff.Description); err != nil {
 			fmt.Printf("\n==========\n%s\n==========\n", err.Error())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -77,7 +77,7 @@ Documentation:
 			pkgs = "packages"
 		}
 
-		mrTitle := fmt.Sprintf("Composer update: %d %s", len(diff.Packages), pkgs)
+		mrTitle := fmt.Sprintf(app.Config.MRTitlePrefix + "%d %s", len(diff.Packages), pkgs)
 
 		if err := app.CreateMergeRequest(mrTitle, diff.Description); err != nil {
 			fmt.Printf("\n==========\n%s\n==========\n", err.Error())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -99,6 +99,7 @@ func init() {
 	rootCmd.Flags().StringSliceVarP(&app.Config.ComposerFlags, "composer-flags", "f", []string{}, "Custom composer flags")
 	rootCmd.Flags().StringVarP(&app.Config.RepoDir, "repo", "r", ".", "Repository directory")
 	rootCmd.Flags().StringVarP(&app.Config.GitCommitTitle, "commit-title", "t", "Update composer dependencies", "The git commit message title")
+	rootCmd.Flags().StringVarP(&app.Config.MRTitlePrefix, "mr-title-prefix", "p", "Composer update:", "The merge request title prefix")
 
 	if err := rootCmd.Flags().MarkHidden("repo"); err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
Purpose for this change: we’d like to customize the MR title format as some of our clients see those and we’d like them to be a bit more generic.

This is the first time I’ve tinkered with Go; does everything look ok? I wrote it based on the other code in the repo and didn’t test it as it seems fairly straightforward and I’m not familiar enough with Go to know about building/compiling/running/etc.